### PR TITLE
FESBAL-52  Allow relative child without doc id

### DIFF
--- a/src/commands/relative/create-relative.ts
+++ b/src/commands/relative/create-relative.ts
@@ -14,11 +14,15 @@ export class CreateRelative {
     readonly firstName: string,
     readonly lastName: string,
     readonly dateOfBirth: string,
-    readonly typeOfIdentityDocument: TypeOfIdentityDocument,
-    readonly identityDocumentNumber: string
+    readonly typeOfIdentityDocument?: TypeOfIdentityDocument,
+    readonly identityDocumentNumber?: string
   ) {}
 
   public static async handle(command: CreateRelative, register: Register): Promise<void> {
+    if (this.getAge(command.dateOfBirth) < 18 && !command.typeOfIdentityDocument) {
+      throw new Error('If you are above 18 years old, you must register a identity document number')
+    }
+
     register.events(
       new RelativeCreated(
         command.relativeId,
@@ -33,4 +37,7 @@ export class CreateRelative {
     register.events(new RelativeAddedToRecipientUser(command.recipientUserId, command.relativeId))
     await register.flush()
   }
+
+  private static getAge = (birthDate: string): number =>
+    Math.floor((new Date().getTime() - new Date(birthDate).getTime()) / 3.15576e10)
 }

--- a/src/commands/relative/create-relative.ts
+++ b/src/commands/relative/create-relative.ts
@@ -38,6 +38,13 @@ export class CreateRelative {
     await register.flush()
   }
 
-  private static getAge = (birthDate: string): number =>
-    Math.floor((new Date().getTime() - new Date(birthDate).getTime()) / 3.15576e10)
+  private static getAge = (birthDate: string): number => {
+    const now = new Date()
+    const birth = new Date(birthDate)
+    let age = now.getFullYear() - birth.getFullYear()
+    if (now.getMonth() < birth.getMonth() || now.getDate() < birth.getDate()) {
+      age--
+    }
+    return age
+  }
 }

--- a/src/entities/relative.ts
+++ b/src/entities/relative.ts
@@ -13,8 +13,8 @@ export class Relative {
     readonly firstName: string,
     readonly lastName: string,
     readonly dateOfBirth: string,
-    readonly typeOfIdentityDocument: TypeOfIdentityDocument,
-    readonly identityDocumentNumber: string,
+    readonly typeOfIdentityDocument?: TypeOfIdentityDocument,
+    readonly identityDocumentNumber?: string,
     readonly isDeleted: boolean = false
   ) {}
 

--- a/src/events/relative/relative-created.ts
+++ b/src/events/relative/relative-created.ts
@@ -10,8 +10,8 @@ export class RelativeCreated {
     readonly firstName: string,
     readonly lastName: string,
     readonly dateOfBirth: string,
-    readonly typeOfIdentityDocument: TypeOfIdentityDocument,
-    readonly identityDocumentNumber: string
+    readonly typeOfIdentityDocument?: TypeOfIdentityDocument,
+    readonly identityDocumentNumber?: string
   ) {}
 
   public entityID(): UUID {


### PR DESCRIPTION
## Description

When children (under 18 years) are added as family members, adding the document number is not mandatory.

In the backend, we must check the date of birth (which is mandatory) and make the document and document type field mandatory or optional depending on the age.

## Changes

- Changes command, event and entity to allow relatives without doc. id.
- Added age validation in CreateRelative command to throw errors if the relative are older than 18 yo and doesn't have doc. id.

## Checks

- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly